### PR TITLE
Add mybinder environment 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 IPython notebooks for master thesis students to get their master thesis started
 
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jan-janssen/Tutorial/master)
+
 Installing and opening Jupyter Notebook using Anaconda on Windows
 =================================================================
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 IPython notebooks for master thesis students to get their master thesis started
-
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jan-janssen/Tutorial/master)
 
 Installing and opening Jupyter Notebook using Anaconda on Windows

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,4 @@
+channels:
+- conda-forge
+dependencies:
+- yaff


### PR DESCRIPTION
Allow students to execute the notebooks on the open infrastructure from mybinder. No need to download anything, just follow the link: 
https://mybinder.org/v2/gh/jan-janssen/Tutorial/master
I tested the tutorials and apart from the regression part with Graphlab everything works fine. In particular the yaff tutorials work fine on the mybinder infrastructure. 